### PR TITLE
Automatic Wifi STA connection at boot

### DIFF
--- a/examples/bluetooth/esp_ble_mesh/ble_mesh_wifi_coexist/main/Kconfig.projbuild
+++ b/examples/bluetooth/esp_ble_mesh/ble_mesh_wifi_coexist/main/Kconfig.projbuild
@@ -35,4 +35,18 @@ menu "Example Configuration"
 
     endchoice
 
+    config MMB_WIFI_STA_AUTO_JOIN_SSID
+        string "Default Wifi SSID to join at boot"
+        default "testSSID"
+        depends on ESP32_WIFI_ENABLED
+        help
+            Wifi SSID (network name) for the example to connect to automatically at boot
+
+    config MMB_WIFI_STA_AUTO_JOIN_PASSWORD
+        string "Default Wifi password to join at boot"
+        default "testPassword"
+        depends on ESP32_WIFI_ENABLED
+        help
+            Wifi password for the example to connect to automatically at boot
+
 endmenu

--- a/examples/bluetooth/esp_ble_mesh/ble_mesh_wifi_coexist/main/cmd_decl.h
+++ b/examples/bluetooth/esp_ble_mesh/ble_mesh_wifi_coexist/main/cmd_decl.h
@@ -10,3 +10,10 @@
 // Register WiFi functions
 void register_wifi(void);
 void initialise_wifi(void);
+
+/**
+ * @brief The public API wrapper to call wifi_cmd_sta_join() programmatically
+ *
+ * @return true if connection is successful, false otherwise
+ */
+bool wifi_STAJoin(const char *aSSID, const char *aPass);

--- a/examples/bluetooth/esp_ble_mesh/ble_mesh_wifi_coexist/main/cmd_decl.h
+++ b/examples/bluetooth/esp_ble_mesh/ble_mesh_wifi_coexist/main/cmd_decl.h
@@ -7,6 +7,8 @@
  */
 #pragma once
 
+#include <stdbool.h>
+
 // Register WiFi functions
 void register_wifi(void);
 void initialise_wifi(void);

--- a/examples/bluetooth/esp_ble_mesh/ble_mesh_wifi_coexist/main/cmd_wifi.c
+++ b/examples/bluetooth/esp_ble_mesh/ble_mesh_wifi_coexist/main/cmd_wifi.c
@@ -18,6 +18,7 @@
 #include "freertos/event_groups.h"
 #include "esp_wifi.h"
 #include "esp_netif.h"
+#include "esp_netif_ip_addr.h"
 #include "iperf.h"
 
 typedef struct {
@@ -284,6 +285,7 @@ static int wifi_cmd_query(int argc, char **argv)
 {
     wifi_config_t cfg;
     wifi_mode_t mode;
+    uint8_t wifiMac[6] = {0};
 
     esp_wifi_get_mode(&mode);
     if (WIFI_MODE_AP == mode) {
@@ -292,8 +294,26 @@ static int wifi_cmd_query(int argc, char **argv)
     } else if (WIFI_MODE_STA == mode) {
         int bits = xEventGroupWaitBits(wifi_event_group, CONNECTED_BIT, 0, 1, 0);
         if (bits & CONNECTED_BIT) {
-            esp_wifi_get_config(WIFI_IF_STA, &cfg);
-            ESP_LOGI(TAG, "sta mode, connected %s", cfg.ap.ssid);
+            // Get config and mac from esp_wifi
+            (void)esp_wifi_get_config(WIFI_IF_STA, &cfg);
+            (void)esp_wifi_get_mac(WIFI_IF_STA, wifiMac);
+            ESP_LOGI(TAG, "sta mode, connected");
+            ESP_LOGI(TAG, "ssid: %s", cfg.sta.ssid);
+            ESP_LOGI(TAG, "mac : %02x:%02x:%02x:%02x:%02x:%02x",
+                        wifiMac[0], wifiMac[1], wifiMac[2],
+                        wifiMac[3], wifiMac[4], wifiMac[5]);
+
+            // Get IP from esp_netif
+            esp_netif_ip_info_t staIpInfo;
+            if (NULL != sta_netif) {
+                if (ESP_OK == esp_netif_get_ip_info(sta_netif, &staIpInfo)) {
+                        ESP_LOGI(TAG, "ip  : " IPSTR, IP2STR(&staIpInfo.ip));
+                } else {
+                    printf("ERR: esp_netif_get_ip_info\n");
+                }
+            } else {
+                printf("ERR: sta_netif still NULL?\n");
+            }
         } else {
             ESP_LOGI(TAG, "sta mode, disconnected");
         }

--- a/examples/bluetooth/esp_ble_mesh/ble_mesh_wifi_coexist/main/cmd_wifi.c
+++ b/examples/bluetooth/esp_ble_mesh/ble_mesh_wifi_coexist/main/cmd_wifi.c
@@ -177,6 +177,19 @@ static bool wifi_cmd_sta_join(const char *ssid, const char *pass)
     return true;
 }
 
+/**
+ * @brief The public API wrapper to call wifi_cmd_sta_join() programmatically
+ *
+ * @return true if connection is successful false otherwise
+ */
+bool wifi_STAJoin(const char *ssid, const char *pass)
+{
+    assert(NULL != ssid);
+    assert(NULL != pass);
+
+    return wifi_cmd_sta_join(ssid, pass);
+}
+
 static int wifi_cmd_sta(int argc, char **argv)
 {
     int nerrors = arg_parse(argc, argv, (void **) &sta_args);

--- a/examples/bluetooth/esp_ble_mesh/ble_mesh_wifi_coexist/main/main.c
+++ b/examples/bluetooth/esp_ble_mesh/ble_mesh_wifi_coexist/main/main.c
@@ -767,15 +767,19 @@ static void wifi_console_init(void)
     /* Register commands */
     register_wifi();
 
-    printf("\n ==================================================\n");
-    printf(" |       Steps to test WiFi throughput            |\n");
-    printf(" |                                                |\n");
-    printf(" |  1. Print 'help' to gain overview of commands  |\n");
-    printf(" |  2. Configure device to station or soft-AP     |\n");
-    printf(" |  3. Setup WiFi connection                      |\n");
-    printf(" |  4. Run iperf to test UDP/TCP RX/TX throughput |\n");
-    printf(" |                                                |\n");
-    printf(" =================================================\n\n");
+    printf("\n ========================================================\n");
+    printf(" |       Steps to use this test program                   |\n");
+    printf(" |                                                        |\n");
+    printf(" |  1. Setup a Wifi Router with testSSID/testPassword     |\n");
+    printf(" |  2. Setup the DHCP server on router to assign          |\n");
+    printf(" |     a static IP for this device's Mac Address          |\n");
+    printf(" |                                                        |\n");
+    printf(" |  3. Device will auto connect to a known SSID:          |\n");
+    printf(" |     testSSID/testPassword as a Wifi Client             |\n");
+    printf(" |  4. Device will also advertise as ESP-BLE-MESH on BT   |\n");
+    printf(" |                                                        |\n");
+    printf(" |  5. Print 'query' to see wifi connection status        |\n");
+    printf(" ==========================================================\n\n");
 
     // start console REPL
     ESP_ERROR_CHECK(esp_console_start_repl(repl));
@@ -815,5 +819,18 @@ void app_main(void)
         return;
     }
 
+    /* Register WIFI subsystem to accept Console CLI */
     wifi_console_init();
+
+
+    /* Auto start STA mode to connect to a known SSID and Password */
+    const char *testSSID = "testSSID";
+    const char *testPassword = "testPassword";
+
+    printf("\nAuto joining Wifi At: %s / %s\n", testSSID, testPassword);
+    if (true == wifi_STAJoin(testSSID, testPassword)) {
+        printf("\n[OK] (will retry if disconnected)\n");
+    } else {
+        printf("\n[FAIL] Make sure router is reachable\n");
+    }
 }

--- a/examples/bluetooth/esp_ble_mesh/ble_mesh_wifi_coexist/main/main.c
+++ b/examples/bluetooth/esp_ble_mesh/ble_mesh_wifi_coexist/main/main.c
@@ -770,12 +770,16 @@ static void wifi_console_init(void)
     printf("\n ========================================================\n");
     printf(" |       Steps to use this test program                   |\n");
     printf(" |                                                        |\n");
-    printf(" |  1. Setup a Wifi Router with testSSID/testPassword     |\n");
+    printf(" |  1. Setup a Wifi Router with                           |\n");
+    printf(" |     ssid: %s \n", CONFIG_MMB_WIFI_STA_AUTO_JOIN_SSID);
+    printf(" |     pswd: %s \n", CONFIG_MMB_WIFI_STA_AUTO_JOIN_PASSWORD);
+    printf(" |                                                        |\n");
     printf(" |  2. Setup the DHCP server on router to assign          |\n");
     printf(" |     a static IP for this device's Mac Address          |\n");
     printf(" |                                                        |\n");
-    printf(" |  3. Device will auto connect to a known SSID:          |\n");
-    printf(" |     testSSID/testPassword as a Wifi Client             |\n");
+    printf(" |  3. Device will auto connect to the specified SSID     |\n");
+    printf(" |     on boot as a Wifi Client                           |\n");
+    printf(" |                                                        |\n");
     printf(" |  4. Device will also advertise as ESP-BLE-MESH on BT   |\n");
     printf(" |                                                        |\n");
     printf(" |  5. Print 'query' to see wifi connection status        |\n");
@@ -824,11 +828,11 @@ void app_main(void)
 
 
     /* Auto start STA mode to connect to a known SSID and Password */
-    const char *testSSID = "testSSID";
-    const char *testPassword = "testPassword";
+    const char *autoSSID = CONFIG_MMB_WIFI_STA_AUTO_JOIN_SSID;
+    const char *autoPassword = CONFIG_MMB_WIFI_STA_AUTO_JOIN_PASSWORD;
 
-    printf("\nAuto joining Wifi At: %s / %s\n", testSSID, testPassword);
-    if (true == wifi_STAJoin(testSSID, testPassword)) {
+    printf("\nAuto joining Wifi At: %s / %s\n", autoSSID, autoPassword);
+    if (true == wifi_STAJoin(autoSSID, autoPassword)) {
         printf("\n[OK] (will retry if disconnected)\n");
     } else {
         printf("\n[FAIL] Make sure router is reachable\n");


### PR DESCRIPTION
# Why this change
- To support SSRP testing requirement (which thankfully does not need openThread)
- To make it simpler for DUT testing, we make the wifi STA client auto-connect to a known ssid and password (`testSSID` / `testPassword`)
- To make it simpler to get the status of the DUT, we extend the `query` command to show the `ssid, mac-address, and ip-address`
- To give quidance we updated the help message of the example app

# Envisioned use case
- Setup Wifi Router with `testSSID` and `testPassword`
- Boot the DUT and run `query` once connection is established, like this:
```
 ========================================================
 |       Steps to use this test program                   |
 |                                                        |
 |  1. Setup a Wifi Router with                           |
 |     ssid: testSSID  
 |     pswd: testPassword
 |                                                        |
 |  2. Setup the DHCP server on router to assign          |
 |     a static IP for this device's Mac Address          |
 |                                                        |
 |  3. Device will auto connect to the specified SSID     |
 |     on boot as a Wifi Client                           |
 |                                                        |
 |  4. Device will also advertise as ESP-BLE-MESH on BT   |
 |                                                        |
 |  5. Print 'query' to see wifi connection status        |
 ==========================================================


Type 'help' to get the list of commands.
Use UP/DOWN arrows to navigate through command history.
Press TAB when typing command name to auto-complete.

Auto joining Wifi At: testSSID / testPassword
esp> I (6494) iperf: L2 connected
W (6506) wifi:<ba-add>idx:0 (ifx:0, 9c:53:22:61:b6:bb), tid:0, ssn:0, winSize:64
I (7419) esp_netif_handlers: sta ip: 192.168.8.116, mask: 255.255.255.0, gw: 192.168.8.1
I (7421) iperf: got ip

[OK] (will retry if disconnected)

esp> query
I (11767) iperf: sta mode, connected
I (11768) iperf: ssid: testSSID
I (11768) iperf: mac : 10:97:bd:31:9c:10
I (11779) iperf: ip  : 192.168.8.116
```

- On the `router's GUI` setup a `static IPv4 map` on DHCPv4 server. Using `D-Link DIR-605L` as an example
- [DIR-605LManual_v1.00.pdf](https://github.com/mmbnetworks/esp-idf/files/12197665/DIR-605LManual_v1.00.pdf)
![image](https://github.com/mmbnetworks/esp-idf/assets/65364552/dafde53a-8df8-4643-933b-89d696c4d4c2)

- Then on a PC that is connected on the same network, we can initiate `ping -i 1 <ipv4-address>` to send pings once per second
- At the same time, on an Android Phone we can observe that `ESP-BLE-MESH` is being advertised

# Dev Testing
- I was able to Ping over Wifi connected BRD21 and observe the bluetooth device advertised on Android phone (Pixel 3 with Android 12 OS)

# How to build and deploy
- clone this repo and checkout this branch
- run esp-idf `install.sh` to setup the required tool
- run esp-idf `export.sh` to create a build environment
- cd `esp-idf/examples/bluetooth/esp_ble_mesh/ble_mesh_wifi_coexist`
- connect DUT to build PC
- run `idf.py build flash` to build and flash the binary to the DUT.
- connect a terminal (baud 115200-8N1) to see and interact with the DUT's console CLI

# How to customize ssid and password
- These can be customized using `idf.py menuconfig`, look for `CONFIG_MMB_WIFI_STA_*`