### PR TITLE
BAVFW-1560: Depend on the correct WIFI_ENABLED KConfig

### DIFF
--- a/examples/bluetooth/esp_ble_mesh/ble_mesh_wifi_coexist/main/Kconfig.projbuild
+++ b/examples/bluetooth/esp_ble_mesh/ble_mesh_wifi_coexist/main/Kconfig.projbuild
@@ -38,14 +38,14 @@ menu "Example Configuration"
     config MMB_WIFI_STA_AUTO_JOIN_SSID
         string "Default Wifi SSID to join at boot"
         default "testSSID"
-        depends on ESP32_WIFI_ENABLED
+        depends on ESP_WIFI_ENABLED
         help
             Wifi SSID (network name) for the example to connect to automatically at boot
 
     config MMB_WIFI_STA_AUTO_JOIN_PASSWORD
         string "Default Wifi password to join at boot"
         default "testPassword"
-        depends on ESP32_WIFI_ENABLED
+        depends on ESP_WIFI_ENABLED
         help
             Wifi password for the example to connect to automatically at boot
 


### PR DESCRIPTION
There is on `ESP32_WIFI_ENABLED`, use `ESP_WIFI_ENABLED` instead

## Dev Testing
able to `idf.py build` with out compiler error

## Mandatory Reviewer
@hani-n 